### PR TITLE
Windows test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ test_script:
 
 build_script:
   - "%CMD_IN_ENV% python setup.py build"
-  - cd scripts
+  - cd scripts\\for_pyinstaller
   - pyinstaller mzml2isa_cli.spec mzml2isa_cli.py
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,9 @@ build_script:
 test_script:
   - mkdir data
   - cd data
-  - ps: wget http://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS267/Person01_RBC_youth_NEG.mzML 
-  - ps: wget http://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS267/Person02_RBC_youth_NEG.mzML 
+  - ps: wget http://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS267/Person01_RBC_youth_NEG.mzML --output-document=Person01_RBC_youth_NEG.mzML
+  - ps: wget http://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS267/Person02_RBC_youth_NEG.mzML --output-document=Person02_RBC_youth_NEG.mzML 
+  - ps: Get-Content Person02_RBC_youth_NEG.mzML -TotalCount 50 
   - cd ..
   - "%PYTHON%\\python.exe -m mzml2isa -i data -o out_folder\\metabolights -s MTBLS267"
   - ps: wget https://github.com/ISA-tools/ISAvalidator-ISAconverter-BIImanager/releases/download/1.6.5/ISA-validator-1.6.5.zip -o ISA-validator-1.6.5.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,11 @@ environment:
 
 
 install:
+  - pip install pyinstaller
   - "%PYTHON%/Scripts/pip.exe install ."
 
 
 test_script:
-  - pip install pyinstaller
   - mkdir data
   - cd data
   - ps: wget http://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS267/Person01_RBC_youth_NEG.mzML -O Person01_RBC_youth_NEG.mzML
@@ -26,7 +26,7 @@ test_script:
 build_script:
   - "%CMD_IN_ENV% python setup.py build"
   - cd scripts
-  - pyinstaller -F --paths=qt;ontologies;%PYTHON%\Lib\site-packages\PyQt5\Qt\bin -F --icon=qt\assets\graphics\ebi_icon.ico main.py 
+  - pyinstaller mzml2isa_cli.spec mzml2isa_cli.py
 
 artifacts:
    - path: scripts\for_pyinstaller\dist\mzml2isa_cli.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,6 @@ install:
   - "%PYTHON%/Scripts/pip.exe install ."
 
 
-build_script:
-  # Build the compiled extension
-- "%CMD_IN_ENV% python setup.py build"
-
 test_script:
   - pip install pyinstaller
   - mkdir data
@@ -28,6 +24,7 @@ test_script:
   - java -cp ISA-validator-1.6.5\isatools_deps.jar org.isatools.isatab.manager.SimpleManager validate out_folder\metabolights\MTBLS267 Configurations\MetaboLightsConfig20140506\
 
 build_script:
+  - "%CMD_IN_ENV% python setup.py build"
   - cd scripts
   - pyinstaller -F --paths=qt;ontologies;%PYTHON%\Lib\site-packages\PyQt5\Qt\bin -F --icon=qt\assets\graphics\ebi_icon.ico main.py 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ build_script:
 - "%CMD_IN_ENV% python setup.py build"
 
 test_script:
+  - pip install pyinstaller
   - mkdir data
   - cd data
   - ps: wget http://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS267/Person01_RBC_youth_NEG.mzML -O Person01_RBC_youth_NEG.mzML
@@ -26,11 +27,27 @@ test_script:
   - unzip ISAcreatorMetaboLights.zip
   - java -cp ISA-validator-1.6.5\isatools_deps.jar org.isatools.isatab.manager.SimpleManager validate out_folder\metabolights\MTBLS267 Configurations\MetaboLightsConfig20140506\
 
-#after_test:
-#  # If tests are successful, create binary packages for the project.
-#  - "%PYTHON%/Scripts/pip.exe install wheel"
-#  - "%CMD_IN_ENV% python setup.py bdist_wheel"
-#  - "%CMD_IN_ENV% python setup.py bdist_wininst"
-#  - "%CMD_IN_ENV% python setup.py bdist_msi"
-#  - ps: "ls dist"
+build_script:
+  - cd scripts
+  - pyinstaller -F --paths=qt;ontologies;%PYTHON%\Lib\site-packages\PyQt5\Qt\bin -F --icon=qt\assets\graphics\ebi_icon.ico main.py 
+
+artifacts:
+   - path: scripts\for_pyinstaller\dist\mzml2isa_cli.exe
+     name: mzml2isa_cli
+
+
+
+deploy:
+  provider: GitHub
+  description: 'Release description'
+  auth_token:
+    secure: a1VIb788bLXA/fLgAoEJshK1aXtGdj79BNvzPg+YfAIrYhp6yaA4gJa6vp4BpWHS
+  artifact: main
+  draft: false
+  prerelease: true
+  force_update: true
+  on:
+    branch: master
+    appveyor_repo_tag: true
+
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ build_script:
 test_script:
   - mkdir data
   - cd data
-  - ps: wget http://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS267/Person01_RBC_youth_NEG.mzML --output-document=Person01_RBC_youth_NEG.mzML
-  - ps: wget http://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS267/Person02_RBC_youth_NEG.mzML --output-document=Person02_RBC_youth_NEG.mzML 
+  - ps: wget http://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS267/Person01_RBC_youth_NEG.mzML -O Person01_RBC_youth_NEG.mzML
+  - ps: wget http://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS267/Person02_RBC_youth_NEG.mzML -O Person02_RBC_youth_NEG.mzML 
   - ps: Get-Content Person02_RBC_youth_NEG.mzML -TotalCount 50 
   - cd ..
   - "%PYTHON%\\python.exe -m mzml2isa -i data -o out_folder\\metabolights -s MTBLS267"

--- a/mzml2isa/mzml.py
+++ b/mzml2isa/mzml.py
@@ -448,7 +448,7 @@ class mzMLmeta(object):
 
                     if e.attrib['version']:
                         self.meta[name+' software version'] = {'value': e.attrib['version']}
-                    software_cvParam = e.iterfind('s:cvParam', namespaces=self.ns)
+                    software_cvParam = e.iterfind('s:cvParam', self.ns)
                     for ie in software_cvParam:
                         self.meta[name+' software'] = {'accession':ie.attrib['accession'], 'name':ie.attrib['name'],
                                                        'ref': ie.attrib['cvRef']}

--- a/scripts/for_pyinstaller/hook-openpyxl.py
+++ b/scripts/for_pyinstaller/hook-openpyxl.py
@@ -1,0 +1,5 @@
+# hook-openpyxl.py
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('openpyxl')

--- a/scripts/for_pyinstaller/mzml2isa_cli.py
+++ b/scripts/for_pyinstaller/mzml2isa_cli.py
@@ -1,4 +1,12 @@
-from mzml2isa import parsing
+from mzml2isa import parsing, mzml, isa
+import pronto
+
 
 if __name__ == '__main__':
+    
     parsing.main()
+
+    # this tmp list is so for automated checking
+    # of code sees that we are using the imports
+    # really they are just required for pyinstaller
+    tmp = [mzml, isa, pronto]

--- a/scripts/for_pyinstaller/mzml2isa_cli.py
+++ b/scripts/for_pyinstaller/mzml2isa_cli.py
@@ -2,8 +2,7 @@ from mzml2isa import parsing, mzml, isa
 import pronto
 
 
-if __name__ == '__main__':
-    from pronto import utils    
+if __name__ == '__main__':  
     parsing.main()
 
 

--- a/scripts/for_pyinstaller/mzml2isa_cli.py
+++ b/scripts/for_pyinstaller/mzml2isa_cli.py
@@ -1,0 +1,6 @@
+from mzml2isa import parsing, mzml, isa
+import pronto
+
+
+if __name__ == '__main__':
+    parsing.main()

--- a/scripts/for_pyinstaller/mzml2isa_cli.py
+++ b/scripts/for_pyinstaller/mzml2isa_cli.py
@@ -2,7 +2,7 @@ from mzml2isa import parsing, mzml, isa
 import pronto
 
 
-if __name__ == '__main__':  
+if __name__ == '__main__':
     parsing.main()
 
 

--- a/scripts/for_pyinstaller/mzml2isa_cli.py
+++ b/scripts/for_pyinstaller/mzml2isa_cli.py
@@ -3,8 +3,9 @@ import pronto
 
 
 if __name__ == '__main__':
-    
+    from pronto import utils    
     parsing.main()
+
 
     # this tmp list is so for automated checking
     # of code sees that we are using the imports

--- a/scripts/for_pyinstaller/mzml2isa_cli.py
+++ b/scripts/for_pyinstaller/mzml2isa_cli.py
@@ -1,6 +1,4 @@
-from mzml2isa import parsing, mzml, isa
-import pronto
-
+from mzml2isa import parsing
 
 if __name__ == '__main__':
     parsing.main()

--- a/scripts/for_pyinstaller/mzml2isa_cli.spec
+++ b/scripts/for_pyinstaller/mzml2isa_cli.spec
@@ -4,7 +4,7 @@ block_cipher = None
 
 
 a = Analysis(['mzml2isa_cli.py'],
-             pathex=['..\\mzml2isa'],
+             pathex=['..\\mzml2isa','%PYTHON%\Lib\site-packages\\\lib\\site-packages\\pronto'],
              binaries=None,
              datas= [ ('..\\..\\mzml2isa\\templates\\a_imzML.txt', 'mzml2isa\\templates' ),
 		      ('..\\..\\mzml2isa\\templates\\a_mzML.txt', 'mzml2isa\\templates' ),
@@ -14,13 +14,14 @@ a = Analysis(['mzml2isa_cli.py'],
                       ('..\\..\\mzml2isa\\templates\\s_mzML.txt', 'mzml2isa\\templates' ),
                       ('..\\..\\mzml2isa\\ontologies\\imagingMS.obo', 'mzml2isa\\ontologies' ),
 		      ('..\\..\\mzml2isa\\ontologies\\psi-ms.obo', 'mzml2isa\\ontologies' )],
-             hiddenimports=[],
+             hiddenimports=['pronto'],
              hookspath=['.'],
              runtime_hooks=[],
              excludes=[],
              win_no_prefer_redirects=False,
              win_private_assemblies=False,
              cipher=block_cipher)
+
 pyz = PYZ(a.pure, a.zipped_data,
              cipher=block_cipher)
 exe = EXE(pyz,

--- a/scripts/for_pyinstaller/mzml2isa_cli.spec
+++ b/scripts/for_pyinstaller/mzml2isa_cli.spec
@@ -1,0 +1,35 @@
+# -*- mode: python -*-
+
+block_cipher = None
+
+
+a = Analysis(['mzml2isa_cli.py'],
+             pathex=['..\\mzml2isa'],
+             binaries=None,
+             datas= [ ('..\\..\\mzml2isa\\templates\\a_imzML.txt', 'mzml2isa\\templates' ),
+		      ('..\\..\\mzml2isa\\templates\\a_mzML.txt', 'mzml2isa\\templates' ),
+		      ('..\\..\\mzml2isa\\templates\\i_imzML.txt', 'mzml2isa\\templates' ),
+                      ('..\\..\\mzml2isa\\templates\\i_mzML.txt', 'mzml2isa\\templates' ),
+                      ('..\\..\\mzml2isa\\templates\\s_imzML.txt', 'mzml2isa\\templates' ),
+                      ('..\\..\\mzml2isa\\templates\\s_mzML.txt', 'mzml2isa\\templates' ),
+                      ('..\\..\\mzml2isa\\ontologies\\imagingMS.obo', 'mzml2isa\\ontologies' ),
+		      ('..\\..\\mzml2isa\\ontologies\\psi-ms.obo', 'mzml2isa\\ontologies' )],
+             hiddenimports=[],
+             hookspath=['.'],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='mzml2isa_cli',
+          debug=False,
+          strip=False,
+          upx=True,
+          console=True )

--- a/scripts/for_pyinstaller/mzml2isa_cli.spec
+++ b/scripts/for_pyinstaller/mzml2isa_cli.spec
@@ -4,7 +4,7 @@ block_cipher = None
 
 
 a = Analysis(['mzml2isa_cli.py'],
-             pathex=['..\\mzml2isa','%PYTHON%\Lib\site-packages\\\lib\\site-packages\\pronto'],
+             pathex=['..\\mzml2isa','%PYTHON%\\lib\\site-packages\\pronto'],
              binaries=None,
              datas= [ ('..\\..\\mzml2isa\\templates\\a_imzML.txt', 'mzml2isa\\templates' ),
 		      ('..\\..\\mzml2isa\\templates\\a_mzML.txt', 'mzml2isa\\templates' ),


### PR DESCRIPTION
- Fix for Python 2.7 vs 3.5 compatibility (see file mzml2isa.py).  One of the iterfind() functions had the 'namespace' argument. For some reason Python 2.7 doesn't like it if you specifically detail the namespace argument. I think this [ stack-overflow  link](http://stackoverflow.com/questions/29695794/typeerror-iter-takes-no-keyword-arguments) is a related problem.

- An executable is now created with AppVeyor that can be accessed from the artefact tab from the AppVeyor output. The executable is created with pyinstaller and can run without python installed. The code used for this is located in the '[scripts/for_pyinstaller](https://github.com/ISA-tools/mzml2isa/tree/windows-test/scripts/for_pyinstaller)' directory

- The executable should automatically be added to the next release when a tag is pushed to gihtub. 