### PR TITLE
Platform fix

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/mzml2isa/__init__.py
+++ b/mzml2isa/__init__.py
@@ -37,7 +37,7 @@ from __future__ import absolute_import
 
 __author__ = 'Thomas Lawson, Martin Larralde'
 __credits__ = 'Thomas Lawson, Martin Larralde, Reza Salek, Ken Haug, Christoph Steinbeck'
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 __license__ = 'GPLv3'
 
 try:

--- a/mzml2isa/isa.py
+++ b/mzml2isa/isa.py
@@ -110,17 +110,20 @@ class ISA_Tab(object):
         """
         split = kwargs.get('split', True)
 
-        platforms = [meta['Instrument'] for meta in metalist if 'Instrument' in meta]
+        platforms = [meta['Instrument']['name'] for meta in metalist if 'Instrument' in meta]
 
-        if len(set([p['name'] for p in platforms])) > 1:
+        if len(set(platforms)) > 1:
             print('WARNING: The mzML files are derived from multiple instrument types, this can be problematic'
-                  'as the "platform" used in the ISAcreator templates uses 1 instrument type per assay,'
-                  'please check the Investigation file to ensure the correct "platform" is being used')
+                  'as the "platform" used in the ISAcreator typically uses 1 instrument type per assay,'
+                  'please check the Investigation output file to ensure the correct "platform" has been assigned'
+                  'to the correct assay file.')
+
+        platform_str = ", ".join(set(platforms))
 
         if split:
-            self.isa_env['Platform'] = platforms[:2]
+            self.isa_env['Platform'] = [platform_str]*2
         else:
-            self.isa_env['Platform'] = platforms[0]
+            self.isa_env['Platform'] = [platform_str]
 
         if not os.path.exists(self.isa_env['out_dir']):
             os.makedirs(self.isa_env['out_dir'])

--- a/mzml2isa/isa.py
+++ b/mzml2isa/isa.py
@@ -108,9 +108,19 @@ class ISA_Tab(object):
             split (bool, optional): a boolean stating if assay files should be split
                 based on their polarities. [default: True]
         """
-        split=kwargs.get('split', True)
+        split = kwargs.get('split', True)
 
-        self.isa_env['Platform'] = [ next((meta['Instrument'] for meta in metalist if 'Instrument' in meta), '') ]
+        platforms = [meta['Instrument'] for meta in metalist if 'Instrument' in meta]
+
+        if len(set([p['name'] for p in platforms])) > 1:
+            print('WARNING: The mzML files are derived from multiple instrument types, this can be problematic'
+                  'as the "platform" used in the ISAcreator templates uses 1 instrument type per assay,'
+                  'please check the Investigation file to ensure the correct "platform" is being used')
+
+        if split:
+            self.isa_env['Platform'] = platforms[:2]
+        else:
+            self.isa_env['Platform'] = platforms[0]
 
         if not os.path.exists(self.isa_env['out_dir']):
             os.makedirs(self.isa_env['out_dir'])

--- a/mzml2isa/templates/i_imzML.txt
+++ b/mzml2isa/templates/i_imzML.txt
@@ -64,7 +64,7 @@ Study Assay Measurement Type Term Source REF	"{{Measurement type[{}][ref]}}"
 Study Assay Technology Type	"{{Technology type[{}][name]}}"
 Study Assay Technology Type Term Accession Number	"{{Technology type[{}][accession]}}"
 Study Assay Technology Type Term Source REF	"{{Technology type[{}][ref]}}"
-Study Assay Technology Platform	"{{Platform[{}][name]}}"
+Study Assay Technology Platform	"{{Platform[{}]}}"
 STUDY PROTOCOLS
 Study Protocol Name	"Sample collection"	"Preparation"	"Mass spectrometry"	"Histology"	"Data transformation"	"Metabolite identification"
 Study Protocol Type	"Sample collection"	"Preparation"	"Mass spectrometry"	"Histology"	"Data transformation"	"Metabolite identification"

--- a/mzml2isa/templates/i_mzML.txt
+++ b/mzml2isa/templates/i_mzML.txt
@@ -64,7 +64,7 @@ Study Assay Measurement Type Term Source REF	"{{Measurement type[{}][ref]}}"
 Study Assay Technology Type	"{{Technology type[{}][name]}}"
 Study Assay Technology Type Term Accession Number	"{{Technology type[{}][accession]}}"
 Study Assay Technology Type Term Source REF	"{{Technology type[{}][ref]}}"
-Study Assay Technology Platform	"{{Platform[{}][name]}}"
+Study Assay Technology Platform	"{{Platform[{}]}}"
 STUDY PROTOCOLS
 Study Protocol Name	"Sample collection"	"Extraction"	"Chromatography"	"Mass spectrometry"	"Data transformation"	"Metabolite identification"
 Study Protocol Type	"Sample collection"	"Extraction"	"Chromatography"	"Mass spectrometry"	"Data transformation"	"Metabolite identification"


### PR DESCRIPTION
Fix for issue #27 

"Platform" not recorded properly in the Investigation file. 

Problem occurs when user has have both positive and negative mzML and the user has selected to split the mzML files into 2 assays (1 for pos and 1 for neg).

To solve this I have added as small fix that checks if positive and negative files should be separated into different assays. If this is true then I simply store two "Platform" names accordingly in the investigation file. (The "Platform" name is set as the instrument name derived from the mzML files)

NOTE: If there are multiple mzML files with different instrument names (e.g. Q-Exactive, LTQ Orbitrap) then a warning is given to check the "Platform" is recorded properly. The platform will be recorded as a combination of both instruments e.g ("Q-Exactive, LTQ Orbitrap") in these cases.

I think this is an unlikely occurrence anyway as in most cases I imagine it is one instrument name per assay.
