### PR TITLE
v1.0.3 (entry point fix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
     - $HOME/.config/isatools/
 
 python:
-- '2.7'
 - '3.5'
 - '3.6'
 - '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ cache:
     - $HOME/.config/isatools/
 
 python:
+- '2.7'
 - '3.5'
 - '3.6'
 - '3.7'
+- '3.8'
 
 
 # cache:

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -5,4 +5,4 @@ pip
 setuptools
 wheel
 twine
-pyinstaller  ; sys_platform == 'win32'
+pyinstaller==3.5 ; sys_platform == 'win32'

--- a/mzml2isa/__init__.py
+++ b/mzml2isa/__init__.py
@@ -9,7 +9,7 @@ References:
     [2] http://isa-tools.org/format.html
 
 Authors:
-    - Thomas Lawson       [tnl495@bham.ac.uk]
+    - Thomas Lawson       [lawsontn@bham.ac.uk]
     - Martin Larralde     [martin.larralde@ens-cachan.fr]
 
 Help provided from:
@@ -35,7 +35,7 @@ from __future__ import unicode_literals
 
 __author__ = 'Thomas Lawson, Martin Larralde'
 __credits__ = 'Thomas Lawson, Martin Larralde, Ralf Weber, Reza Salek, Ken Haug, Christoph Steinbeck'
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 __license__ = 'GPLv3'
 
 try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ setup_requires =
 tests_require =
 	parameterized ~=0.6
 	isatools ~=0.10         ; python_version > '2'
+	isatools <= 0.10         ; python_version < '3'
 	fs.archive[tar.xz] ~=0.5
 install_requires =
 	cached-property ~=1.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,11 @@ install_requires =
 	openpyxl ~=2.5
 	lxml ~=4.2              ; python_version < '3'
 
+[options.entry_points]
+console_scripts =
+    mzml2isa = mzml2isa.parsing:main
+
+
 [options.extras_require]
 pb =
 	tqdm ~=4.25

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
 	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
 	Topic :: Text Processing :: Markup :: XML
 	Topic :: Scientific/Engineering :: Bio-Informatics
 	Topic :: Scientific/Engineering :: Chemistry

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
-isatools ~=0.10 ; python_version > '2'
+isatools ~=0.10 ; python_version > '2.7'
+isatools <=0.10 ; python_version < '3'
 parameterized ~=0.6.1
 fs.archive[tar.xz] ~=0.5


### PR DESCRIPTION
* Entry point bug fix. The command line tool was no longer available after install. Fixed by adding the entry point option to setup.cfg file
* Add test for py 3.8 and update relevant section in setup.cfg