### PR TITLE
allowing higher versions of openpyxl (needed if using Pandas 1.3.4 an…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
 	fs ~=2.4
 	pronto ~=0.12
 	six ~=1.11
-	openpyxl ~=2.5
+	openpyxl >=2.5
 	lxml ~=4.2              ; python_version < '3'
 
 [options.entry_points]


### PR DESCRIPTION
…d higher) and solve a dependency conflict in the isa-api